### PR TITLE
Make the code compatible with arm64 architecture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mond"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian L. Troutwine", "J.C. Moyer"]
 description = "A Rust Lua 5.3"
 documentation = "https://docs.rs/mond"

--- a/lua-source/src/Makefile
+++ b/lua-source/src/Makefile
@@ -7,7 +7,7 @@
 PLAT= none
 
 CC= gcc -std=gnu99
-CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS)
+CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_2 $(SYSCFLAGS) $(MYCFLAGS) -fsigned-char
 LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)
 


### PR DESCRIPTION
Turns out, arm64 architecture expects char type to be unsigned by default: http://blog.cdleary.com/2012/11/arm-chars-are-unsigned-by-default/

This makes the code fail to build on arm64 because of functions like this: http://pgl.yoyo.org/luai/i/lua_pushlstring

The solution here is to just force chars to be always signed, unless `unsigned char` is explicitly specified.